### PR TITLE
Open localhost in browser

### DIFF
--- a/sanelfactory/PORNIRE_SITE.md
+++ b/sanelfactory/PORNIRE_SITE.md
@@ -1,0 +1,27 @@
+# 🚀 Cum să pornești site-ul Sanel Factory
+
+## Metoda 1: Script automat (Recomandat)
+Rulează în terminal:
+```bash
+cd sanelfactory
+npm run open
+```
+
+Acest script va:
+- ✅ Verifica și instala dependențele (dacă e necesar)
+- ✅ Porni serverul pe http://localhost:3000
+- ✅ Deschide automat browserul
+
+## Metoda 2: Manual
+```bash
+cd sanelfactory
+npm install   # doar prima dată
+npm start     # pornește serverul
+```
+Apoi deschide manual în browser: http://localhost:3000
+
+## Pentru oprire
+Apasă `Ctrl+C` în terminal
+
+---
+💡 **Notă**: Site-ul va rula pe portul 3000. Asigură-te că acest port nu este deja folosit.

--- a/sanelfactory/package.json
+++ b/sanelfactory/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "start": "node server.js",
     "dev": "nodemon server.js",
+    "open": "./start-and-open.sh",
     "build": "npm run minify-css && npm run minify-js",
     "minify-css": "cleancss -o css/styles.min.css css/styles.css && cleancss -o css/upload.min.css css/upload.css",
     "minify-js": "uglifyjs js/main.js -o js/main.min.js && uglifyjs js/upload.js -o js/upload.min.js && uglifyjs js/chatbot.js -o js/chatbot.min.js",

--- a/sanelfactory/start-and-open.sh
+++ b/sanelfactory/start-and-open.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# Culori pentru output
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+echo -e "${BLUE}🚀 Pornesc serverul Sanel Factory...${NC}"
+
+# Verifică dacă node_modules există
+if [ ! -d "node_modules" ]; then
+    echo -e "${BLUE}📦 Instalez dependențele...${NC}"
+    npm install
+fi
+
+# Pornește serverul în background
+npm start &
+SERVER_PID=$!
+
+# Așteaptă puțin ca serverul să pornească
+echo -e "${BLUE}⏳ Aștept ca serverul să pornească...${NC}"
+sleep 3
+
+# Deschide browserul
+echo -e "${GREEN}🌐 Deschid browserul pe http://localhost:3000${NC}"
+if command -v xdg-open > /dev/null; then
+    xdg-open http://localhost:3000
+elif command -v gnome-open > /dev/null; then
+    gnome-open http://localhost:3000
+elif command -v firefox > /dev/null; then
+    firefox http://localhost:3000
+elif command -v google-chrome > /dev/null; then
+    google-chrome http://localhost:3000
+elif command -v chromium > /dev/null; then
+    chromium http://localhost:3000
+else
+    echo -e "${GREEN}Nu am putut deschide browserul automat. Te rog deschide manual: http://localhost:3000${NC}"
+fi
+
+echo -e "${GREEN}✅ Serverul rulează! Apasă Ctrl+C pentru a opri.${NC}"
+
+# Așteaptă ca serverul să fie oprit
+wait $SERVER_PID


### PR DESCRIPTION
Add `npm run open` command to automatically start the server and open the site in the browser, fulfilling the user's request.

---

[Open in Web](https://cursor.com/agents?id=bc-6ecf507b-45f0-4ea7-83e9-dfb6d08adfcb) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-6ecf507b-45f0-4ea7-83e9-dfb6d08adfcb) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)